### PR TITLE
only limit find and findOne searches if removed is not already in the selector

### DIFF
--- a/behaviours/softRemovable.js
+++ b/behaviours/softRemovable.js
@@ -5,10 +5,12 @@ CollectionBehaviours.defineBehaviour('softRemovable', function(getTransform, arg
     return false;
   });
   self.before.find(function (userId, selector, options) {
-    selector.removed = {$exists: false};
+    if(typeof selector.removed === 'undefined')
+      selector.removed = {$exists: false};
   });
   self.before.findOne(function (userId, selector, options) {
-    selector.removed = {$exists: false};
+    if(typeof selector.removed === 'undefined')
+      selector.removed = {$exists: false};
   });
   self.unRemove = function(selector){
     //TODO


### PR DESCRIPTION
Without the ability to do a find query where the removed flag is set it's hard to display to the user what's been flagged as deleted.
