### PR TITLE
Making unRemove of softRemovable work

### DIFF
--- a/behaviours/softRemovable.js
+++ b/behaviours/softRemovable.js
@@ -1,29 +1,11 @@
 CollectionBehaviours.defineBehaviour('softRemovable', function(getTransform, args){
-  var self = this;
-  self.before.remove(function (userId, doc) {
-    self.update({_id: doc._id}, {$set: {removed: true, removedAt: Date.now()}});
-    return false;
-  });
-  self.before.find(function (userId, selector, options) {
-    selector.removed = {$exists: false};
-  });
-  self.before.findOne(function (userId, selector, options) {
-    selector.removed = {$exists: false};
-  });
-  self.unRemove = function(selector){
-    //TODO
-    self.update(selector, {$set: {removed: false, unRemovedAt: Date.now()}});
-  };
-});
-
-CollectionBehaviours.defineBehaviour('softRemovable', function(getTransform, args){
   var self = this, method = "softRemovable_"+this._name;
   // server method to by-pass "can only remove by ID" on the client
   if (Meteor.isServer) {
     var m = {};
     m[method] = function(selector) { 
-	    self.unRemove(selector); 
-	  }
+      self.unRemove(selector); 
+    }
     Meteor.methods(m);
   }
   self.before.remove(function (userId, doc) {
@@ -36,25 +18,25 @@ CollectionBehaviours.defineBehaviour('softRemovable', function(getTransform, arg
     return false;
   });
   self.before.find(function (userId, selector, options) {
-	if(typeof selector.removed === 'undefined')
-		selector.removed = {$exists: false};
+    if(typeof selector.removed === 'undefined')
+      selector.removed = {$exists: false};
   });
   self.before.findOne(function (userId, selector, options) {
-	if(typeof selector.removed === 'undefined')
-		selector.removed = {$exists: false};
+    if(typeof selector.removed === 'undefined')
+      selector.removed = {$exists: false};
   });
   self.unRemove = function(selector){
-  	// self.update(selector, {$unset: {removed: true}}) does not work because it will trigger a 
-  	// call to findOne method to retrieve the "doc" for other hooks, but it will return null because the document has the removed flag set
-  	// solution: call the update with { _id: "<id>", removed: true } (see impl of find and findOne above.)
-  	// but: Meteor only permits removes by ID on the client
+    // self.update(selector, {$unset: {removed: true}}) does not work because it will trigger a 
+    // call to findOne method to retrieve the "doc" for other hooks, but it will return null because the document has the removed flag set
+    // solution: call the update with { _id: "<id>", removed: true } (see impl of find and findOne above.)
+    // but: Meteor only permits removes by ID on the client
     // thus, we have to send the request to the server via a RPC when then will do the update with the removed: true flag set
     if (Meteor.isClient) {
-	    Meteor.call(method, selector);
-  	} else {
+      Meteor.call(method, selector);
+    } else {
       if (_.isString(selector)) selector = { _id: selector }
       selector.removed = true
       self.update(selector, { $unset: { removed: true }, $set: { unRemovedAt: Date.now() } });
-	  }
+    }
   };
 });


### PR DESCRIPTION
Guess the "//TODO" note in unRemove was due to the fact that the method was actually not working.
I made two changes.
First, the update call to remove the "removed" flag needs to have "removed: true" in the selector so that the findOne method does not filter out the document to be undeleted.
But Meteor does not permit to add this to an update on the client side. (Error "Error: Not permitted. Untrusted code may only update documents by ID. [403]")
First I was trying to add a custom flag to the options object to signal that an undelete is taking place, but the options do not get forwarded to the findOne method, unfortunately.
Thus the Meteor.method that sends the undelete request to the server and calls the update there with the "removed: true" flag. Honestly, I think it's not a beautiful solution, but after trying everything else I could think of, it seems to be the only one actually working.
