### PR TITLE
Selector can be unset on client. If so, create it.

### DIFF
--- a/behaviours/softRemovable.js
+++ b/behaviours/softRemovable.js
@@ -10,10 +10,14 @@ CollectionBehaviours.defineBehaviour('softRemovable', function(getTransform, arg
     return false;
   });
   self.before.find(function (userId, selector, options) {
+    if (typeof selector === 'undefined')
+      selector = {}
     if(typeof selector.removed === 'undefined')
       selector.removed = {$exists: false};
   });
   self.before.findOne(function (userId, selector, options) {
+    if (typeof selector === 'undefined')
+      selector = {}
     if(typeof selector.removed === 'undefined')
       selector.removed = {$exists: false};
   });


### PR DESCRIPTION
We had an issue where `selector` was undefined on the client. I added a couple of `if`s to create it if it doesn't already exist.
