### PR TITLE
Track the user id as well

### DIFF
--- a/behaviours/trackable.js
+++ b/behaviours/trackable.js
@@ -7,7 +7,7 @@ CollectionBehaviours.defineBehaviour('trackable', function(getTransform, args){
       if(doc[field]){
         if(!modifier.$push)
           modifier.$push = {};
-        track = {trackedAt: Date.now()};
+        track = {trackedAt: Date.now(), updatedBy: !!userId ? userId : "N/A"};
         track[field] = doc[field];
         modifier.$push[field+"Track"] = track;
       }


### PR DESCRIPTION
Since this behavior seems more likely t be for auditing purposes, it's important to know who to point fingers at.

Granted, change may have been public or server initiated without a user context, hence the "N/A"
