### PR TITLE
Use collection-extensions

### DIFF
--- a/collection-behaviours.js
+++ b/collection-behaviours.js
@@ -1,4 +1,3 @@
-var constructor = Mongo.Collection;
 var behaviours = {};
 
 CollectionBehaviours = {};
@@ -30,16 +29,6 @@ CollectionBehaviours.extendCollectionInstance = function (self) {
   });
 };
 
-Mongo.Collection = function () {
-  var ret = constructor.apply(this, arguments);
+Meteor.addCollectionExtension(function () {
   CollectionBehaviours.extendCollectionInstance(this);
-  return ret;
-};
-
-Mongo.Collection.prototype = Object.create(constructor.prototype);
-
-for (var func in constructor) {
-  if (constructor.hasOwnProperty(func)) {
-    Mongo.Collection[func] = constructor[func];
-  }
-}
+});

--- a/package.js
+++ b/package.js
@@ -18,13 +18,15 @@ Package.onUse(function (api, where) {
     api.use([
       'mongo',
       'underscore',
+      'lai:collection-extensions@0.1.3',
       'matb33:collection-hooks@0.7.6'
     ], both);
   } else {
     api.use([
       'mongo-livedata',
       'underscore',
-      'collection-hooks'
+      'lai:collection-extensions',
+      'matb33:collection-hooks'
     ], both);
   }
 


### PR DESCRIPTION
This is a friendly and cooperative effort to get all packages that modify the `Mongo.Collection` constructor to use a [centralized "monkey-patching" package](https://github.com/rclai/meteor-collection-extensions) to do away with the package issues that arise as a result of monkey-patching the constructor multiple times. For example, [this issue](https://github.com/Sewdn/meteor-collection-behaviours/issues/7) that you're having is fixed when you depend on my package.

[`dburles:mongo-collection-instances`](https://github.com/dburles/mongo-collection-instances/pull/14) has already jumped on board with this.

I'm trying to pull request third-party packages like yours one by one to make sure there are no potential issues. Eventually I will also pull request collection-hooks as well. As a matter of fact, I was able to run `matb33:collection-hooks`'s tests and have them all pass using my package (and also without using my package). [Here's my fork (`collection-extensions` branch) of collection-hooks that uses my package for you to test](https://github.com/rclai/meteor-collection-hooks/tree/collection-extensions).

Also, if you're not convinced, you can git clone [my fork of your package (`collection-extensions` branch)](https://github.com/rclai/meteor-collection-behaviours/tree/collection-extensions) in your local `packages` folder to test it out. I was hoping that you've written tests for your package so I wrote a few of my own (that I haven't published yet) and saw that your package works.